### PR TITLE
Remove the need for ripgrep

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,5 @@ jobs:
     needs: build
     steps:
     - uses: actions/checkout@v2
-    - name: install ripgrep
-      run: cargo install ripgrep
     - name: Ensures tests are all passing.
       run: cargo test --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_json = "1.0.53"
 toml = "0.5.6"
-time = {version = "*", optional = true} # SCOTT
-random = {version = "*", optional = true} # SCOTT
 regex = "1.3.9"
 lazy_static = "1.4.0"
 structopt = "0.3.14"
-
-[features]
-my_time = ["time"]
+walkdir = "2.3.1"


### PR DESCRIPTION
Remove the need for ripgrep to be installed on the user machine by using the [walkdir](https://crates.io/crates/walkdir) crate :)


Closes #7 